### PR TITLE
fix: Melhorias no Kanban Board (Update Modal e Drag-and-Drop)

### DIFF
--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -72,6 +72,24 @@ export default class TaskController {
           <label>Descrição:</label>
           <textarea id="edit-description" rows="3">${task.description || ''}</textarea>
         </div>
+        <div class="form-grid">
+          <div class="form-group">
+            <label>Prioridade:</label>
+            <select id="edit-priority">
+              <option value="low" ${task.priority === 'low' ? 'selected' : ''}>Baixa</option>
+              <option value="medium" ${task.priority === 'medium' || !task.priority ? 'selected' : ''}>Média</option>
+              <option value="high" ${task.priority === 'high' ? 'selected' : ''}>Alta</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label>Status:</label>
+            <select id="edit-status">
+              <option value="pending" ${task.status === 'pending' ? 'selected' : ''}>Pendente</option>
+              <option value="in-progress" ${task.status === 'in-progress' ? 'selected' : ''}>Em Progresso</option>
+              <option value="completed" ${task.status === 'completed' ? 'selected' : ''}>Concluído</option>
+            </select>
+          </div>
+        </div>
         <div class="form-actions">
           <button id="update-task-btn" class="add-btn">Atualizar</button>
         </div>
@@ -81,8 +99,11 @@ export default class TaskController {
       document.getElementById('update-task-btn').onclick = () => {
         const title = document.getElementById('edit-title').value.trim();
         const description = document.getElementById('edit-description').value.trim();
+        const priority = document.getElementById('edit-priority').value;
+        const status = document.getElementById('edit-status').value;
+        
         if (title) {
-          this.model.updateTask(id, { title, description });
+          this.model.updateTask(id, { title, description, priority, status });
           this.view.renderTasks(this.model.tasks);
           this.view.closeModal();
         } else {
@@ -134,7 +155,7 @@ export default class TaskController {
   }
 
   handleDrop(id, newStatus) {
-    this.model.updateTask(id, { status: newStatus.replace(" ", "-") });
+    this.model.updateTask(id, { status: newStatus });
     this.view.renderTasks(this.model.tasks);
   }
 

--- a/src/js/view.js
+++ b/src/js/view.js
@@ -112,6 +112,11 @@ export default class TaskView {
     document.getElementById('pending-count').textContent = pendingTasks.length;
     document.getElementById('in-progress-count').textContent = inProgressTasks.length;
     document.getElementById('completed-count').textContent = completedTasks.length;
+
+    // Re-inicializar drag and drop após renderizar novas tarefas
+    if (this._onDropHandler) {
+      this.setupDragAndDrop(this._onDropHandler);
+    }
   }
 
   renderTaskList(containerId, tasks) {
@@ -271,6 +276,7 @@ export default class TaskView {
   }
 
   setupDragAndDrop(onDrop) {
+    this._onDropHandler = onDrop;
     const tasks = document.querySelectorAll('.task');
     const columns = document.querySelectorAll('.column .tasks');
 
@@ -298,10 +304,11 @@ export default class TaskView {
         }
       });
 
-      column.addEventListener('drop', () => {
+      column.addEventListener('drop', (e) => {
+        e.preventDefault();
         const draggingTask = document.querySelector('.dragging');
         if (draggingTask) {
-          const newStatus = column.parentElement.id.replace('-column', '').replace('-', ' ');
+          const newStatus = column.id.replace('-tasks', '');
           onDrop(draggingTask.dataset.id, newStatus);
         }
       });


### PR DESCRIPTION
Este PR resolve as seguintes questões:
1. Adiciona campos de 'Prioridade' e 'Status' ao modal de edição de tarefas.
2. Corrige a persistência do status ao arrastar tarefas entre colunas.
3. Garante que os eventos de drag-and-drop sejam reinicializados após cada renderização.

Resolve #9.

Checklist:
- [x] Campos de prioridade/status no modal.
- [x] Atualização imediata no Kanban após edição.
- [x] Persistência de drag-and-drop.
- [x] Eventos de drag-and-drop ativos após renderização.